### PR TITLE
fix: resolve clippy collapsible_match in keyboard event arm

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1856,7 +1856,12 @@ impl ApplicationHandler<KoiEvent> for Koi {
                 s.render();
             }
             WindowEvent::KeyboardInput { event: key_event, .. } => {
-                if s.handle_keyboard(key_event, &self.event_proxy, &mut self.font_size, self.scale) {
+                // Bind the result before branching: folding this `if` into a match guard
+                // (as clippy's collapsible_match suggests) would move `key_event` inside the
+                // guard, which the compiler rejects (E0507) since it is consumed by value.
+                let should_exit =
+                    s.handle_keyboard(key_event, &self.event_proxy, &mut self.font_size, self.scale);
+                if should_exit {
                     event_loop.exit();
                 }
             }


### PR DESCRIPTION
Resolves the `clippy::collapsible_match` error that was failing CI on `main` (tracked in MR-3 / MR-2).

### Change
Bind `handle_keyboard`'s result before branching in the `WindowEvent::KeyboardInput` arm. Folding the `if` into a match guard (as clippy suggests) would move `key_event` into the guard, which the compiler rejects (E0507) since it is consumed by value.

### Verified locally (rustc/clippy 1.95.0, matching CI)
- `cargo clippy -- -D warnings` → exit 0
- `cargo build --release` → ok
- `cargo test` → 17 passed, 0 failed

Co-Authored-By: Paperclip <noreply@paperclip.ing>