### PR TITLE
fix: SIGHUP shell process group in Pane::drop to unblock tmux teardown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -935,6 +935,7 @@ dependencies = [
  "glutin",
  "glutin-winit",
  "image",
+ "libc",
  "log",
  "parking_lot",
  "raw-window-handle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,5 +18,8 @@ parking_lot = "0.12"
 arboard = { version = "3", features = ["image-data"] }
 image = { version = "0.25", default-features = false, features = ["png"] }
 
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [build-dependencies]
 gl_generator = "0.14"

--- a/src/tabs.rs
+++ b/src/tabs.rs
@@ -17,11 +17,25 @@ pub struct Pane {
     pub term: Arc<FairMutex<Term<EventProxy>>>,
     pub notifier: Notifier,
     _pty_thread: Option<PtyJoinHandle>,
+    #[cfg(unix)]
+    shell_pid: u32,
 }
 
 impl Drop for Pane {
     fn drop(&mut self) {
-        // Send shutdown, then join the PTY thread to release the Term mutex.
+        // On Unix, SIGHUP the shell's whole process group before we join.
+        // alacritty_terminal's Pty::drop already SIGHUPs the shell PID, but not
+        // the group — so a foreground child like tmux keeps the shell parked in
+        // wait4, which parks Pty::drop's child.wait(), which parks this join()
+        // on the main thread. Signaling -pgid delivers SIGHUP to tmux too so
+        // the shell can actually return from wait4 and exit.
+        #[cfg(unix)]
+        {
+            let pid = self.shell_pid as i32;
+            if pid > 0 {
+                unsafe { libc::kill(-pid, libc::SIGHUP) };
+            }
+        }
         let _ = self.notifier.0.send(Msg::Shutdown);
         if let Some(handle) = self._pty_thread.take() {
             let _ = handle.join();
@@ -87,6 +101,8 @@ impl TabManager {
             ..tty::Options::default()
         };
         let pty = tty::new(&pty_opts, window_size, 0).expect("create PTY");
+        #[cfg(unix)]
+        let shell_pid = pty.child().id();
 
         let pty_event_loop = PtyEventLoop::new(
             term.clone(),
@@ -100,7 +116,16 @@ impl TabManager {
         let notifier = Notifier(pty_event_loop.channel());
         let pty_thread = pty_event_loop.spawn();
 
-        (id, Pane { term, notifier, _pty_thread: Some(pty_thread) })
+        (
+            id,
+            Pane {
+                term,
+                notifier,
+                _pty_thread: Some(pty_thread),
+                #[cfg(unix)]
+                shell_pid,
+            },
+        )
     }
 
     /// Add a new tab with one pane.


### PR DESCRIPTION
## Summary

Fixes MR-7: main-thread hang when closing a pane whose shell is running tmux (or any foreground child that doesn't exit on its own signal).

3-second repro (100% reliable, macOS): launch koi → Cmd+Shift+D → type `tmux` in one pane → Cmd+W → app freezes, must Force Quit. macOS sample showed 34s parked in `__wait4`, 23/23 frames identical: `Pane::drop → handle.join() → EventLoop drop → Pty::drop → __wait4`.

## Why the hang exists

- `Pane::drop` (main thread) sends `Msg::Shutdown`, then joins the PTY thread.
- The PTY thread drops `alacritty_terminal::tty::Pty`, whose `Drop` calls `libc::kill(shell_pid, SIGHUP)` then `child.wait()`.
- That SIGHUP targets **just the shell PID**, not its process group. tmux is a child of the shell in the same pgroup (`setsid` runs in `pre_exec`), so tmux never gets the signal.
- The shell itself is already parked in `wait4` waiting on tmux, so it can't process its pending SIGHUP.
- `child.wait()` blocks in `waitpid` forever → PTY thread never returns → main-thread `join()` hangs.

## Fix

- Capture the shell PID via `pty.child().id()` **before** `pty` is moved into `PtyEventLoop::new` — this is the only accessor `alacritty_terminal 0.25.1` exposes.
- In `Pane::drop`, before send-shutdown/join, send `SIGHUP` to `-pid` (the process group) so tmux gets it too. tmux dies → shell's `wait4` returns → shell handles its own pending SIGHUP and exits → `child.wait()` returns → PTY thread ends → `join()` returns.

Gated behind `#[cfg(unix)]`.

## Files touched

- `src/tabs.rs` — capture `shell_pid`, SIGHUP the pgroup on drop
- `Cargo.toml` — add `libc = "0.2"` under `[target.'cfg(unix)'.dependencies]` (was already transitive via `alacritty_terminal`, promoted to direct for the syscall)
- `Cargo.lock` — dep graph update

Nothing else outside `src/tabs.rs` was modified.

## Test plan

- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo test` — 17 passed
- [x] `cargo build --release` succeeds
- [ ] macOS: run the 3-step repro on your daily-driver macbook, confirm Cmd+W no longer hangs
- [ ] macOS: normal-exit case unchanged — type `exit` in a pane, then Cmd+W or Cmd+Q, verify no regression (kill(-pid, SIGHUP) returns ESRCH when the pgroup is already gone, harmless)

## Deliberately deferred (future cards, per issue instructions)

- **K0-b**: 500ms watchdog that SIGKILLs the shell PID if SIGHUP is ignored (defense for zsh disowned children or SIGHUP-ignoring processes)
- **K0-c**: move pane teardown off the main thread entirely (proper graveyard-thread pattern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
