### PR TITLE
fix: unblock PTY shutdown when tmux is running in the pane

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -935,6 +935,7 @@ dependencies = [
  "glutin",
  "glutin-winit",
  "image",
+ "libc",
  "log",
  "parking_lot",
  "raw-window-handle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,5 +18,8 @@ parking_lot = "0.12"
 arboard = { version = "3", features = ["image-data"] }
 image = { version = "0.25", default-features = false, features = ["png"] }
 
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [build-dependencies]
 gl_generator = "0.14"

--- a/src/tabs.rs
+++ b/src/tabs.rs
@@ -17,11 +17,25 @@ pub struct Pane {
     pub term: Arc<FairMutex<Term<EventProxy>>>,
     pub notifier: Notifier,
     _pty_thread: Option<PtyJoinHandle>,
+    #[cfg(unix)]
+    shell_pid: u32,
 }
 
 impl Drop for Pane {
     fn drop(&mut self) {
-        // Send shutdown, then join the PTY thread to release the Term mutex.
+        // On Unix, SIGHUP the shell's whole process group before we join.
+        // alacritty_terminal's Pty::drop already SIGHUPs the shell PID, but not
+        // the group — so a foreground child like tmux keeps the shell parked in
+        // wait4, which parks Pty::drop's child.wait(), which parks this join()
+        // on the main thread. Signaling -pgid delivers SIGHUP to tmux too so
+        // the shell can actually return from wait4 and exit.
+        #[cfg(unix)]
+        {
+            let pid = self.shell_pid as i32;
+            if pid > 0 {
+                unsafe { libc::kill(-pid, libc::SIGHUP) };
+            }
+        }
         let _ = self.notifier.0.send(Msg::Shutdown);
         if let Some(handle) = self._pty_thread.take() {
             let _ = handle.join();
@@ -87,6 +101,8 @@ impl TabManager {
             ..tty::Options::default()
         };
         let pty = tty::new(&pty_opts, window_size, 0).expect("create PTY");
+        #[cfg(unix)]
+        let shell_pid = pty.child().id();
 
         let pty_event_loop = PtyEventLoop::new(
             term.clone(),
@@ -100,7 +116,16 @@ impl TabManager {
         let notifier = Notifier(pty_event_loop.channel());
         let pty_thread = pty_event_loop.spawn();
 
-        (id, Pane { term, notifier, _pty_thread: Some(pty_thread) })
+        (
+            id,
+            Pane {
+                term,
+                notifier,
+                _pty_thread: Some(pty_thread),
+                #[cfg(unix)]
+                shell_pid,
+            },
+        )
     }
 
     /// Add a new tab with one pane.


### PR DESCRIPTION
## Summary

Fixes a hang in `koi` when closing a pane while `tmux` is running inside it (repro: split → run `tmux` → `Cmd+W` on that pane → main thread hangs forever, UI frozen).

## Root cause

The teardown chain deadlocks on the main thread:

1. `Pane::drop` (main thread) calls `handle.join()` to wait for the PTY reader thread.
2. The PTY reader thread's `Pty::drop` calls `waitpid` on the shell process.
3. `waitpid` blocks because `tmux` (a child of the shell) never received a hangup, so it keeps the PTY session alive and the shell never exits.

Result: PTY thread waits on `tmux`, main thread waits on PTY thread → UI locked.

## Fix (ed8dc06)

In `Pane::drop`, send `SIGHUP` to the shell's **process group** (`kill(-pid, SIGHUP)`) before joining the PTY thread. Sending to the process group (negative pid) delivers the signal to every process in the shell's session — including `tmux` — so both children terminate cleanly, `waitpid` returns, and the reader thread joins.

The shell PID is now captured from `pty.child()` in `Pane::new` before `pty` moves into the event loop.

## Why `libc` was added as a direct dependency

`libc::kill` is needed for the `#[cfg(unix)]` signal call. `libc` was already in the tree transitively via `alacritty_terminal`, so this only makes an existing dependency explicit — it doesn't pull in anything new.

## Also in this PR

- `eb9874b` — clippy `collapsible_match` fix in the keyboard event arm (unrelated but needed for `-D warnings`).

## Verification

Local (Linux, `sleeper6`):

- `cargo clippy -- -D warnings` — clean
- `cargo test` — 17/17 pass
- `cargo build --release` — succeeds

Visual verification (actual pane-close + tmux repro) will be done by @0xjjjjjj on macOS — the headless Linux env here can't reproduce the tmux+PTY interaction on the macOS daily-driver env where CI runs.

## Follow-ups (tracked separately, not in this PR)

- K0-b: 500ms watchdog SIGKILL if the shell ignores SIGHUP.
- K0-c: move pane teardown off the main thread (graveyard pattern).