### PR TITLE
feat: cross-platform terminal bell (MR-16)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -940,6 +940,7 @@ dependencies = [
  "parking_lot",
  "raw-window-handle",
  "unicode-width",
+ "windows",
  "winit",
 ]
 
@@ -2245,10 +2246,74 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
+name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-result",
+ "windows-strings",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result",
+ "windows-targets 0.52.6",
+]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,5 +21,8 @@ image = { version = "0.25", default-features = false, features = ["png"] }
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
+[target.'cfg(windows)'.dependencies]
+windows = { version = "0.58", features = ["Win32_UI_WindowsAndMessaging"] }
+
 [build-dependencies]
 gl_generator = "0.14"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1924,6 +1924,16 @@ impl ApplicationHandler<KoiEvent> for Koi {
                     extern "C" { fn NSBeep(); }
                     unsafe { NSBeep(); }
                 }
+                #[cfg(target_os = "windows")]
+                {
+                    use windows::Win32::UI::WindowsAndMessaging::{MessageBeep, MB_OK};
+                    unsafe { let _ = MessageBeep(MB_OK); }
+                }
+                #[cfg(all(unix, not(target_os = "macos")))]
+                {
+                    use winit::window::UserAttentionType;
+                    s.window.request_user_attention(Some(UserAttentionType::Critical));
+                }
                 s.bell_flash_until = Some(std::time::Instant::now()
                     + std::time::Duration::from_millis(150));
                 s.needs_redraw = true;


### PR DESCRIPTION
Closes MR-16.

## Summary
Replaces the macOS-only `NSBeep` block in the `Bell` event handler (`src/main.rs`) with a target-conditional bell for macOS, Windows, and Linux/other-unix. Visual `bell_flash_until` logic is untouched and runs on all platforms.

- **macOS**: keeps existing `NSBeep` — audible.
- **Windows**: `MessageBeep(MB_OK)` via a target-conditional `windows` crate — audible.
- **Linux / other unix**: winit `request_user_attention(UserAttentionType::Critical)` — visual (window-manager attention).

`Cargo.toml` gains only the target-conditional `[target.'cfg(windows)'.dependencies] windows` entry.

## Verification
- Linux: `cargo clippy -- -D warnings` and `cargo build --release` both green.
- Windows: `cargo check --target x86_64-pc-windows-gnu` green (build-verified, not runtime-verified).
- macOS: build-verified only via the existing `#[cfg(target_os = "macos")]` block; no runtime path changed.

## Test plan
- [ ] macOS: bell (e.g. `printf '\a'`) still produces an audible NSBeep and the visual flash.
- [ ] Windows: bell produces an audible `MessageBeep` and the visual flash.
- [ ] Linux: bell triggers window-manager attention (taskbar/urgency hint) and the visual flash.