### PR TITLE
build: Windows portable exe + packaging script (MR-24)

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ PTY EventLoop (per pane, separate thread)    │
 
 ## Build
 
-Requires Rust toolchain and macOS (uses Core Text for font rasterization).
+Requires the Rust toolchain and macOS (uses Core Text for font rasterization).
 
 ```bash
 make build     # release build
@@ -84,6 +84,42 @@ make app       # build + assemble Koi.app bundle
 make install   # build + install to /Applications
 make clean     # cargo clean
 ```
+
+## Build for Windows
+
+Windows is a secondary target. The release binary is built natively on a Windows host with the MSVC toolchain and the MSVC C runtime linked statically, so the resulting `koi.exe` runs on a stock Windows machine without any Visual C++ redistributable installed.
+
+### Prerequisites
+
+- Windows 10/11 x64
+- [Visual Studio Build Tools](https://visualstudio.microsoft.com/downloads/) with the **Desktop development with C++** workload (provides the MSVC linker and Windows SDK)
+- [Rustup](https://rustup.rs/) with the `x86_64-pc-windows-msvc` target (the default host toolchain when you install rustup on Windows):
+
+  ```powershell
+  rustup default stable-x86_64-pc-windows-msvc
+  ```
+
+- PowerShell 7+ (`pwsh`) if you want to use the packaging script directly. PowerShell 5.1 that ships with Windows also works — just invoke it as `powershell.exe`.
+
+### Build the exe
+
+From the repo root:
+
+```powershell
+pwsh -File bundle\windows\build-windows.ps1
+```
+
+Produces `target\release\koi.exe` with a statically linked MSVC runtime (equivalent to compiling with `/MT`).
+
+### Package a portable zip
+
+To also produce a redistributable `target\koi-windows-x86_64.zip` containing `koi.exe` and `README.md`:
+
+```powershell
+pwsh -File bundle\windows\build-windows.ps1 -Zip
+```
+
+Unzip and run `koi.exe` — no installer required.
 
 ## License
 

--- a/bundle/windows/build-windows.ps1
+++ b/bundle/windows/build-windows.ps1
@@ -1,0 +1,65 @@
+<#
+.SYNOPSIS
+    Build a distributable Windows release of koi.
+
+.DESCRIPTION
+    Produces target/release/koi.exe with the MSVC C runtime linked
+    statically (equivalent to /MT), so the resulting binary does not
+    require an installed Visual C++ redistributable on the target
+    machine.
+
+    With -Zip, also emits target/koi-windows-x86_64.zip containing the
+    exe plus README and LICENSE for portable distribution.
+
+.PARAMETER Zip
+    After building, package the exe and top-level docs into a portable
+    zip at target/koi-windows-x86_64.zip.
+
+.EXAMPLE
+    pwsh -File bundle/windows/build-windows.ps1
+    pwsh -File bundle/windows/build-windows.ps1 -Zip
+
+.NOTES
+    Requires the x86_64-pc-windows-msvc Rust toolchain and MSVC build
+    tools (Visual Studio Build Tools with the "Desktop development with
+    C++" workload). Run from the repository root.
+#>
+[CmdletBinding()]
+param(
+    [switch]$Zip
+)
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+Push-Location $repoRoot
+try {
+    Write-Host "==> Building koi.exe (release, +crt-static)"
+    $env:RUSTFLAGS = '-C target-feature=+crt-static'
+    & cargo build --release
+    if ($LASTEXITCODE -ne 0) { throw "cargo build failed with exit code $LASTEXITCODE" }
+
+    $exe = Join-Path $repoRoot 'target/release/koi.exe'
+    if (-not (Test-Path $exe)) { throw "expected artifact not found: $exe" }
+    Write-Host "==> Built $exe"
+
+    if ($Zip) {
+        $stage = Join-Path $repoRoot 'target/koi-windows-x86_64'
+        $zip   = Join-Path $repoRoot 'target/koi-windows-x86_64.zip'
+        if (Test-Path $stage) { Remove-Item -Recurse -Force $stage }
+        if (Test-Path $zip)   { Remove-Item -Force $zip }
+        New-Item -ItemType Directory -Path $stage | Out-Null
+
+        Copy-Item $exe (Join-Path $stage 'koi.exe')
+        foreach ($doc in 'README.md') {
+            $src = Join-Path $repoRoot $doc
+            if (Test-Path $src) { Copy-Item $src $stage }
+        }
+
+        Compress-Archive -Path (Join-Path $stage '*') -DestinationPath $zip -Force
+        Write-Host "==> Packaged $zip"
+    }
+}
+finally {
+    Pop-Location
+}


### PR DESCRIPTION
## Summary

Adds a Windows release path for koi alongside the existing macOS bundle. No changes to the macOS `Makefile` targets, `build.rs`, or `src/` platform gating.

- `bundle/windows/build-windows.ps1` — PowerShell script that runs `cargo build --release` with `RUSTFLAGS=-C target-feature=+crt-static` so the MSVC C runtime links statically (equivalent to `/MT`). `koi.exe` therefore runs on a stock Windows machine without a VC++ redistributable install.
- `-Zip` flag on the script packages `target\koi-windows-x86_64.zip` (exe + `README.md`) for portable distribution — no installer required.
- README gains a "Build for Windows" section covering the MSVC toolchain prereqs, the build command, and the packaging step.

Ticket: [MR-24](/MR/issues/MR-24) (parent [MR-22](/MR/issues/MR-22)). Builds on the `windows-latest` matrix leg added by [MR-23](/MR/issues/MR-23) (`ci: add windows-latest to CI matrix`).

### Follow-up

The final K7 acceptance item — exercising this build on the `windows-latest` CI leg and dropping `continue-on-error` — is deferred to a follow-up issue. The bot token pushing this PR is missing the `workflow` OAuth scope, so `.github/workflows/ci.yml` cannot be modified from here. Follow-up will be filed against the same branch or as its own PR by an agent/user with `workflow` scope.

## Test plan

- [ ] `pwsh -File bundle\windows\build-windows.ps1` on a Windows host produces `target\release\koi.exe`
- [ ] `pwsh -File bundle\windows\build-windows.ps1 -Zip` also produces `target\koi-windows-x86_64.zip`
- [ ] `koi.exe` runs on a Windows machine that does not have the VC++ redistributable installed
- [ ] macOS `make build` / `make app` / `make install` are unaffected
