### PR TITLE
ci: add windows-latest to CI matrix (allowed to fail)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,12 @@ env:
 
 jobs:
   check:
-    runs-on: macos-latest
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.os == 'windows-latest' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
 
@@ -25,7 +30,9 @@ jobs:
         run: cargo build --release
 
       - name: Clippy
+        if: matrix.os == 'macos-latest'
         run: cargo clippy -- -D warnings
 
       - name: Test
+        if: matrix.os == 'macos-latest'
         run: cargo test


### PR DESCRIPTION
MR-18 K3 — Add Windows to CI matrix.

## Change
- Adds `windows-latest` to the CI matrix alongside `macos-latest`.
- `cargo build --release` runs on both.
- `continue-on-error: ${{ matrix.os == 'windows-latest' }}` — Windows leg is allowed to fail (K4 removes this once green).
- `clippy` and `test` gated to macOS to avoid Windows regressions (macOS CI unchanged).

## Acceptance criteria (from MR-18)
- [x] `.github/workflows/ci.yml` has a matrix job that runs `cargo build --release` on `windows-latest` in addition to macOS.
- [x] `continue-on-error: true` on the Windows leg only.
- [x] macOS CI still passes (no regression — clippy/test still run only on macOS).

Unblocks MR-15.

Co-Authored-By: Paperclip <noreply@paperclip.ing>