### PR TITLE
Windows static-CRT build script + visual smoke helper (MR-25)

### DIFF
--- a/bundle/windows/build-windows.ps1
+++ b/bundle/windows/build-windows.ps1
@@ -1,0 +1,65 @@
+<#
+.SYNOPSIS
+    Build a distributable Windows release of koi.
+
+.DESCRIPTION
+    Produces target/release/koi.exe with the MSVC C runtime linked
+    statically (equivalent to /MT), so the resulting binary does not
+    require an installed Visual C++ redistributable on the target
+    machine.
+
+    With -Zip, also emits target/koi-windows-x86_64.zip containing the
+    exe plus README for portable distribution.
+
+.PARAMETER Zip
+    After building, package the exe and top-level docs into a portable
+    zip at target/koi-windows-x86_64.zip.
+
+.EXAMPLE
+    pwsh -File bundle/windows/build-windows.ps1
+    pwsh -File bundle/windows/build-windows.ps1 -Zip
+
+.NOTES
+    Requires the x86_64-pc-windows-msvc Rust toolchain and MSVC build
+    tools (Visual Studio Build Tools with the "Desktop development with
+    C++" workload). Run from the repository root.
+#>
+[CmdletBinding()]
+param(
+    [switch]$Zip
+)
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+Push-Location $repoRoot
+try {
+    Write-Host "==> Building koi.exe (release, +crt-static)"
+    $env:RUSTFLAGS = '-C target-feature=+crt-static'
+    & cargo build --release
+    if ($LASTEXITCODE -ne 0) { throw "cargo build failed with exit code $LASTEXITCODE" }
+
+    $exe = Join-Path $repoRoot 'target/release/koi.exe'
+    if (-not (Test-Path $exe)) { throw "expected artifact not found: $exe" }
+    Write-Host "==> Built $exe"
+
+    if ($Zip) {
+        $stage = Join-Path $repoRoot 'target/koi-windows-x86_64'
+        $zip   = Join-Path $repoRoot 'target/koi-windows-x86_64.zip'
+        if (Test-Path $stage) { Remove-Item -Recurse -Force $stage }
+        if (Test-Path $zip)   { Remove-Item -Force $zip }
+        New-Item -ItemType Directory -Path $stage | Out-Null
+
+        Copy-Item $exe (Join-Path $stage 'koi.exe')
+        foreach ($doc in 'README.md') {
+            $src = Join-Path $repoRoot $doc
+            if (Test-Path $src) { Copy-Item $src $stage }
+        }
+
+        Compress-Archive -Path (Join-Path $stage '*') -DestinationPath $zip -Force
+        Write-Host "==> Packaged $zip"
+    }
+}
+finally {
+    Pop-Location
+}

--- a/scripts/windows-smoke.ps1
+++ b/scripts/windows-smoke.ps1
@@ -1,0 +1,59 @@
+#requires -Version 5.0
+# koi Windows visual smoke test
+#
+# Launches koi.exe (from -KoiPath, or koi.exe next to this script, or the
+# repo's target\release\koi.exe), waits ~5 seconds for the window to
+# render, then grabs a screenshot of the primary screen and saves it
+# next to this script as koi-smoke-<yyyyMMdd-HHmmss>.png.
+#
+# Usage:
+#   PS> .\windows-smoke.ps1                            # auto-locate koi.exe
+#   PS> .\windows-smoke.ps1 -KoiPath C:\path\to\koi.exe
+
+[CmdletBinding()]
+param(
+    [string] $KoiPath,
+    [int]    $SleepSeconds = 5
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not $KoiPath) {
+    $candidates = @(
+        (Join-Path $PSScriptRoot 'koi.exe'),
+        (Join-Path (Split-Path -Parent $PSScriptRoot) 'target\release\koi.exe')
+    )
+    $KoiPath = $candidates | Where-Object { Test-Path -LiteralPath $_ } | Select-Object -First 1
+    if (-not $KoiPath) {
+        throw "koi.exe not found next to this script or at target\release\koi.exe. Pass -KoiPath explicitly."
+    }
+}
+elseif (-not (Test-Path -LiteralPath $KoiPath)) {
+    throw "koi.exe not found at '$KoiPath'."
+}
+
+Write-Host "Launching $KoiPath ..."
+$proc = Start-Process -FilePath $KoiPath -PassThru
+Write-Host "Started PID $($proc.Id). Waiting $SleepSeconds seconds for window to render..."
+Start-Sleep -Seconds $SleepSeconds
+
+Add-Type -AssemblyName System.Windows.Forms
+Add-Type -AssemblyName System.Drawing
+
+$screen = [System.Windows.Forms.Screen]::PrimaryScreen.Bounds
+$bitmap = New-Object System.Drawing.Bitmap $screen.Width, $screen.Height
+$graphics = [System.Drawing.Graphics]::FromImage($bitmap)
+$graphics.CopyFromScreen($screen.Location, [System.Drawing.Point]::Empty, $screen.Size)
+
+$stamp    = Get-Date -Format 'yyyyMMdd-HHmmss'
+$outPath  = Join-Path $PSScriptRoot ("koi-smoke-$stamp.png")
+$bitmap.Save($outPath, [System.Drawing.Imaging.ImageFormat]::Png)
+
+$graphics.Dispose()
+$bitmap.Dispose()
+
+Write-Host "Saved screenshot: $outPath"
+Write-Host ""
+Write-Host "koi is still running (PID $($proc.Id))."
+Write-Host "Continue your manual checks in the window (dir / dark-mode toggle / Ctrl+C)."
+Write-Host "Close the koi window when you are done, or run: Stop-Process -Id $($proc.Id)"


### PR DESCRIPTION
## Summary

Agent prep for MR-20 visual smoke on Windows (Paperclip CTO / MR-25).

- `bundle/windows/build-windows.ps1` — Windows release build with `+crt-static` so `koi.exe` runs on a stock Windows box without a VC++ redistributable install. With `-Zip`, produces `target/koi-windows-x86_64.zip` (koi.exe + README).
- `scripts/windows-smoke.ps1` — launches `koi.exe`, waits 5 s, snapshots the primary screen to `koi-smoke-<timestamp>.png` next to the script, then leaves koi running for manual `dir` / dark-mode / Ctrl+C checks.

## Follow-up (needs `workflow` scope)

The CI workflow change (windows-latest matrix leg + `actions/upload-artifact@v4` of `target/koi-windows-x86_64.zip`) could not be pushed from this branch because the agent OAuth token lacks the `workflow` scope required to modify `.github/workflows/ci.yml`. Suggested patch is in the MR-25 issue thread.

## Test plan

- [ ] macOS CI still green (unchanged path)
- [ ] Once workflow change lands, windows-latest job produces `koi-windows-x86_64` artifact
- [ ] j runs `scripts/windows-smoke.ps1` from an unzipped release build; screenshot lands next to the script