### PR TITLE
ci: remove continue-on-error on Windows leg (MR-17 K4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,12 @@ env:
 
 jobs:
   check:
-    runs-on: macos-latest
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.os == 'windows-latest' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
 
@@ -25,7 +30,9 @@ jobs:
         run: cargo build --release
 
       - name: Clippy
+        if: matrix.os == 'macos-latest'
         run: cargo clippy -- -D warnings
 
       - name: Test
+        if: matrix.os == 'macos-latest'
         run: cargo test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,6 @@ env:
 jobs:
   check:
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.os == 'windows-latest' }}
     strategy:
       fail-fast: false
       matrix:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,10 @@ image = { version = "0.25", default-features = false, features = ["png"] }
 libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]
-windows = { version = "0.58", features = ["Win32_UI_WindowsAndMessaging"] }
+windows = { version = "0.58", features = [
+    "Win32_System_Diagnostics_Debug",
+    "Win32_UI_WindowsAndMessaging",
+] }
 
 [build-dependencies]
 gl_generator = "0.14"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1926,7 +1926,8 @@ impl ApplicationHandler<KoiEvent> for Koi {
                 }
                 #[cfg(target_os = "windows")]
                 {
-                    use windows::Win32::UI::WindowsAndMessaging::{MessageBeep, MB_OK};
+                    use windows::Win32::System::Diagnostics::Debug::MessageBeep;
+                    use windows::Win32::UI::WindowsAndMessaging::MB_OK;
                     unsafe { let _ = MessageBeep(MB_OK); }
                 }
                 #[cfg(all(unix, not(target_os = "macos")))]


### PR DESCRIPTION
MR-17 K4 — First green Windows CI build.

## What this PR does

1. Removes `continue-on-error: ${{ matrix.os == 'windows-latest' }}` from the CI `check` job so `windows-latest` becomes a required gate.
2. Fixes the Windows-only bell path — MR-16's [PR #29](https://github.com/0xjjjjjj/koi/pull/29) imported `MessageBeep` from the wrong module in the `windows` crate:
    - `Cargo.toml`: add `Win32_System_Diagnostics_Debug` feature to the `windows` dep.
    - `src/main.rs`: import `MessageBeep` from `Win32::System::Diagnostics::Debug` and keep `MB_OK` from `Win32::UI::WindowsAndMessaging`.

Windows-only path — no behavior change on macOS or Linux.

## Evidence

- Failing run before the fix (bell import error): [29166272758](https://github.com/0xjjjjjj/koi/actions/runs/29166272758)
- Passing run after the fix: [29166465787](https://github.com/0xjjjjjj/koi/actions/runs/29166465787) — both `check (macos-latest)` and `check (windows-latest)` green with `cargo build --release`.

## Base

Branched from `ci/windows-matrix` (PR #31 / MR-18 K3), then rebased onto `main` after MR-16 landed. This PR is a superset of #31: it includes the K3 matrix + the K4 removal + the bell fix, so merging this either supersedes #31 or lands cleanly after it.

## Acceptance (MR-17)

- [x] `windows-latest` leg runs `cargo build --release` and must pass (no `continue-on-error`).
- [x] macOS CI unchanged (clippy/test still gated to `macos-latest`).
- [x] Source changes are Windows-only (`#[cfg(target_os = "windows")]`) or additive Cargo feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)