### PR TITLE
test: ConPTY spawn smoke test (MR-21)

### DIFF
--- a/tests/pty_smoke.rs
+++ b/tests/pty_smoke.rs
@@ -1,0 +1,34 @@
+//! Cross-platform PTY spawn smoke test.
+//!
+//! Exercises alacritty_terminal's `tty::new` — the same call koi uses to
+//! spawn a shell — on the real host tty layer:
+//!   - Windows: ConPTY spawning `powershell.exe` (the crate's default).
+//!   - macOS/Linux: `posix_openpt` + fork/exec of the user's shell
+//!     (falling back to `/bin/sh`).
+//!
+//! Passing means the child was created without an OS error. This is the
+//! narrow contract the K5 acceptance criteria call for: prove headless
+//! shell-spawn works on both platforms. The test intentionally does not
+//! drive an event loop or read/write the pipes — that path is covered by
+//! real usage and adds flake surface for CI (Windows GHA images vary in
+//! what conpty.dll gets loaded).
+
+use alacritty_terminal::event::WindowSize;
+use alacritty_terminal::tty::{self, Options};
+
+fn window_size() -> WindowSize {
+    WindowSize { num_lines: 24, num_cols: 80, cell_width: 8, cell_height: 16 }
+}
+
+#[test]
+fn spawns_default_shell() {
+    tty::setup_env();
+
+    let opts = Options::default();
+    let pty = tty::new(&opts, window_size(), 0)
+        .expect("tty::new should spawn the default shell on this platform");
+
+    // Drop immediately — we only care that spawn succeeded. On Windows this
+    // triggers ClosePseudoConsole; on Unix, Pty::drop SIGHUPs the child.
+    drop(pty);
+}


### PR DESCRIPTION
## Summary

Adds a headless integration test (`tests/pty_smoke.rs`) that exercises alacritty_terminal's `tty::new` — the exact entry point koi uses to spawn a shell — and asserts the child was created. On Windows this exercises the **ConPTY** code path (default shell: `powershell.exe`); on macOS/Linux it uses the existing openpt+fork/exec path. Passing means headless shell-spawn works.

Verified locally (Linux dev box) with `cargo test --test pty_smoke` — green in 0.13s.

## MR-21 acceptance status

- ✅ **Smoke test exists** and exercises the real tty layer (this PR).
- ✅ **macOS**: `cargo test` on macos-latest picks up `tests/pty_smoke.rs` automatically once this merges.
- 🟡 **Windows**: Windows CI leg already exists on `ci/windows-matrix` (PR #31) but only runs `cargo build --release`. Adding `cargo test --test pty_smoke` to the Windows leg is a **CI-only edit** and requires the `workflow` OAuth scope, which this agent's token does not carry (same restriction MR-24 / MR-25 hit — see their commit messages).

## Exact CI change needed as a follow-up

Add these three lines after the `Clippy` step in `.github/workflows/ci.yml`:

```yaml
      - name: PTY spawn smoke test
        run: cargo test --test pty_smoke
```

That runs on both matrix legs (no `if:` guard) — the K5 acceptance signal on Windows.

## Scope constraints observed

- Did not touch the main rendering loop.
- Did not refactor existing PTY wiring beyond adding a `tests/` file.
- Uses `alacritty_terminal` directly (already a `[dependencies]` entry); no new crates.

## Test plan

- [x] `cargo test --test pty_smoke` locally (Linux) — passes.
- [ ] `cargo test --test pty_smoke` on macos-latest via existing CI (will run automatically as part of `cargo test`).
- [ ] `cargo test --test pty_smoke` on windows-latest — pending the CI follow-up above.
