### PR TITLE
fix: platform-conditional fallback font (MR-30 K9)

### DIFF
--- a/src/renderer/glyph_cache.rs
+++ b/src/renderer/glyph_cache.rs
@@ -9,6 +9,20 @@ use super::atlas::{Atlas, Glyph};
 const INITIAL_ATLAS_SIZE: i32 = 2048;
 const MAX_ATLAS_SIZE: i32 = 8192;
 
+// Platform-specific fallback font. Each name must be a font that ships with
+// the OS by default so `load_font` cannot panic on a clean install.
+//   - macOS: Menlo ships since 10.6.
+//   - Windows: Consolas ships since Vista (safer than Cascadia Mono, which
+//     is Win Terminal / Win11-era only).
+//   - Other unix: DejaVu Sans Mono is the de-facto default on Debian/Ubuntu
+//     and most desktop distros.
+#[cfg(target_os = "macos")]
+const FALLBACK_FONT: &str = "Menlo";
+#[cfg(target_os = "windows")]
+const FALLBACK_FONT: &str = "Consolas";
+#[cfg(all(unix, not(target_os = "macos")))]
+const FALLBACK_FONT: &str = "DejaVu Sans Mono";
+
 pub struct GlyphCache {
     rasterizer: Rasterizer,
     font_key: FontKey,
@@ -39,9 +53,12 @@ impl GlyphCache {
         let font_key = rasterizer
             .load_font(&font_desc, size)
             .unwrap_or_else(|_| {
-                log::warn!("Font '{}' not found, falling back to Menlo", font_family);
+                log::warn!(
+                    "Font '{}' not found, falling back to {}",
+                    font_family, FALLBACK_FONT
+                );
                 let fallback = FontDesc::new(
-                    "Menlo",
+                    FALLBACK_FONT,
                     Style::Description {
                         slant: Slant::Normal,
                         weight: Weight::Normal,


### PR DESCRIPTION
## Summary
- Fixes a Windows-only panic where the hardcoded `"Menlo"` fallback in `src/renderer/glyph_cache.rs` fails `load_font` because Menlo is a macOS-only system font. K6 visual smoke on Windows 11 caught it after K3/K4 compile CI passed (the fallback is a runtime path).
- Replaces the string literal with a `#[cfg]`-selected constant:
  - macOS -> `Menlo`
  - Windows -> `Consolas` (ships since Vista; safer than Cascadia Mono which is Win11-era)
  - other unix -> `DejaVu Sans Mono`
- `crossfont` 0.8 has no generic-monospace query, so per-platform constants are the minimal fix. Chain-of-candidates and user config are the K9-b / K9-c follow-ups from the issue.

## Test plan
- [x] `cargo check` (linux) clean
- [x] `cargo check --target x86_64-pc-windows-gnu` clean
- [x] `cargo clippy -- -D warnings` clean (linux + windows target)
- [x] `cargo test` — all 18 tests pass
- [ ] Windows CI leg `check (windows-latest)` green
- [ ] Manual: `target\release\koi.exe` on Windows 11 launches without the FontNotFound panic

🤖 Generated with [Claude Code](https://claude.com/claude-code)