### PR TITLE
fix: bundled font invisible to DirectWrite (AddFontMemResourceEx -> AddFontResourceExW+FR_PRIVATE)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,13 @@ install: app
 	cp -r $(APP) /Applications/Koi.app
 	@echo "Installed to /Applications/Koi.app"
 
+windows:
+	powershell -File bundle/windows/build-windows.ps1
+
+windows-zip:
+	powershell -File bundle/windows/build-windows.ps1 -Zip:$$true
+
 clean:
 	cargo clean
 
-.PHONY: build app install clean
+.PHONY: build app install windows windows-zip clean

--- a/src/fonts_registrar.rs
+++ b/src/fonts_registrar.rs
@@ -16,41 +16,57 @@ pub fn register_bundled_fonts() {
 
 #[cfg(target_os = "windows")]
 mod imp {
+    use std::io::Write;
+    use std::os::windows::ffi::OsStrExt;
+    use std::path::PathBuf;
     use std::sync::Once;
-    use windows::Win32::Graphics::Gdi::AddFontMemResourceEx;
+    use windows::core::PCWSTR;
+    use windows::Win32::Graphics::Gdi::{AddFontResourceExW, FR_PRIVATE};
 
     static ONCE: Once = Once::new();
 
+    // AddFontMemResourceEx is NOT enumerable by DirectWrite (per MSDN), so
+    // crossfont's DirectWrite lookup can't resolve the font by name.
+    // AddFontResourceExW + FR_PRIVATE is enumerable and process-scoped.
     pub fn register(faces: &[&[u8]]) {
         ONCE.call_once(|| {
+            let Some(dir) = extract_dir() else {
+                log::warn!("Bundled font extraction dir unavailable; skipping registration");
+                return;
+            };
+            if let Err(e) = std::fs::create_dir_all(&dir) {
+                log::warn!("Failed to create bundled-font dir {:?}: {}", dir, e);
+                return;
+            }
             for (i, bytes) in faces.iter().enumerate() {
-                let mut installed: u32 = 0;
-                // SAFETY: `bytes` is a `'static` slice from `include_bytes!`;
-                // the pointer/length remain valid for the process lifetime.
-                // AddFontMemResourceEx copies the data into a private table,
-                // so the returned handle can be dropped without unregistering
-                // (per MSDN: process-scoped registration).
-                let handle = unsafe {
-                    AddFontMemResourceEx(
-                        bytes.as_ptr() as *const _,
-                        bytes.len() as u32,
-                        None,
-                        &mut installed as *mut u32,
-                    )
+                let path = dir.join(format!("koi-plexmono-{}.otf", i));
+                if !path.exists() {
+                    match std::fs::File::create(&path).and_then(|mut f| f.write_all(bytes)) {
+                        Ok(()) => {}
+                        Err(e) => {
+                            log::warn!("Failed to write bundled font to {:?}: {}", path, e);
+                            continue;
+                        }
+                    }
+                }
+                let wide: Vec<u16> = path.as_os_str().encode_wide().chain(std::iter::once(0)).collect();
+                let added = unsafe {
+                    AddFontResourceExW(PCWSTR(wide.as_ptr()), FR_PRIVATE, None)
                 };
-                if handle.is_invalid() || installed == 0 {
-                    log::warn!(
-                        "AddFontMemResourceEx failed for bundled font #{} ({} bytes)",
-                        i, bytes.len()
-                    );
+                if added == 0 {
+                    log::warn!("AddFontResourceExW failed for {:?}", path);
                 } else {
-                    log::info!(
-                        "Registered bundled font #{} ({} face(s), {} bytes)",
-                        i, installed, bytes.len()
-                    );
+                    log::info!("Registered bundled font #{} via GDI/DirectWrite ({:?})", i, path);
                 }
             }
         });
+    }
+
+    fn extract_dir() -> Option<PathBuf> {
+        std::env::var_os("LOCALAPPDATA")
+            .map(PathBuf::from)
+            .or_else(|| std::env::var_os("TEMP").map(PathBuf::from))
+            .map(|base| base.join("koi").join("fonts"))
     }
 }
 


### PR DESCRIPTION
## Summary

K9-a (bundled Plex Mono, PR #37) shipped but didn't fix the Windows blank-window symptom. Root cause: the CTO used `AddFontMemResourceEx`, but per MSDN "the system does not enumerate fonts loaded with AddFontMemResourceEx." crossfont on Windows uses **DirectWrite**, which resolves fonts by name via system-font-collection enumeration. So the bundled Plex Mono was loaded into GDI's private table but was invisible to DirectWrite — `load_font("IBM Plex Mono")` still fell through to a silent DirectWrite substitution with no matching glyphs, producing the same blank-window state as before.

## Fix

Extract the .otf bytes to `%LOCALAPPDATA%\koi\fonts` on first launch, then call `AddFontResourceExW(path, FR_PRIVATE, NULL)`. That path IS enumerable, is process-scoped (unregistered on process exit), and DirectWrite's system-font-collection picks it up.

## Trade-offs

- Requires filesystem writes (~480KB, one-time). Path lives under `LOCALAPPDATA` so it survives across runs.
- FR_PRIVATE means other Windows apps don't see the font — same isolation as the original design intent.
- Files persist across process exits (fonts get de-registered at process exit but files stay for next launch). Not ideal but avoids re-extraction cost.

## Test plan

- [ ] Windows CI leg green (build only proves it compiles)
- [ ] Manual: j runs `target\release\koi.exe` on Windows 11, verifies shell prompt renders in IBM Plex Mono (not blank, not substituted)

## Deferred

If we ever need in-memory registration on Windows without disk touch, use `IDWriteFactory5::CreateInMemoryFontFileLoader` + `RegisterFontFileLoader` + custom collection. Requires COM plumbing and Windows 10 1703+; not worth it for koi's needs today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)