### PR TITLE
v1.6.0 — Initial Windows support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,43 @@
+# Changelog
+
+## v1.6.0 — 2026-07-12
+
+Initial Windows support.
+
+### Added
+
+- **Windows build** — koi.exe with `+crt-static` runs on stock Windows 10/11 without a VC++ redistributable install (`bundle/windows/build-windows.ps1`, `make windows`, `make windows-zip`).
+- Windows CI matrix (`macos-latest` + `windows-latest`) as required gates on `main`.
+- Bundled IBM Plex Mono fonts (OFL 1.1) registered process-scoped at startup so the font is available without user install (macOS + Linux paths). Windows path currently falls back to Consolas — see `Known issues`.
+- Cross-platform terminal bell: `NSBeep` on macOS, `MessageBeep(MB_OK)` on Windows, `request_user_attention` on Linux.
+- ConPTY smoke test (`tests/pty_smoke.rs`) proves headless shell-spawn on both macOS and Windows.
+- `PerMonitorV2` DPI awareness on Windows.
+
+### Fixed
+
+- **Main-thread hang on pane close with tmux** — `Pane::drop` now sends `SIGHUP` to the shell's process group (not just the bare PID) before joining the PTY thread, so tmux receives the signal and shell's `wait4` returns promptly. Repro was: Cmd+Shift+D → tmux → Cmd+W → 34-second freeze.
+- **Windows blank-window rendering** — `get_glyph` was building `GlyphKey` with `Size::new(0.)`, which crossfont clamps to 1pt internally. On DirectWrite this rasterized every glyph at ~1.33 DIP em size (2×1 pixel bitmaps). Fixed by storing the real `Size` on `GlyphCache` and passing it to every lookup. macOS was hiding the bug because CoreText's crossfont backend ignores `glyph.size` and uses the size bound at `load_font` time.
+- **Windows fallback font panic** — hardcoded `"Menlo"` fallback in `glyph_cache.rs` panicked on any non-macOS platform. Now platform-conditional: `Menlo` on macOS, `Consolas` on Windows, `DejaVu Sans Mono` on other Unix.
+- Cross-platform bell import: `MessageBeep` lives in `Win32::System::Diagnostics::Debug`, not `Win32::UI::WindowsAndMessaging`.
+
+### Changed
+
+- Release builds now link as the `windows` subsystem, so double-click launch on Windows no longer opens a phantom console window. Log output still streams to the parent console when launched from `cmd`/`powershell` (via `AttachConsole(ATTACH_PARENT_PROCESS)`).
+- Branch protection on `main`: PR required, both CI legs (`check (macos-latest)` and `check (windows-latest)`) must pass, linear history, no force-push, no deletion.
+
+### Known issues (Windows)
+
+Cosmetic / feature gaps, not correctness bugs. Filed as separate issues.
+
+- IBM Plex Mono bundled but not visible to DirectWrite: registered fonts via `AddFontResourceExW+FR_PRIVATE` land in GDI's private table, but DirectWrite's shared system font collection is snapshotted at factory creation and doesn't refresh. Real fix requires `IDWriteInMemoryFontFileLoader` + custom `IDWriteFontCollection`, which crossfont doesn't accept via its public API. Falls back to Consolas.
+- Terminal mouse click events not forwarded to inner apps.
+- Screenshot feature not ported.
+- Windows executable has no embedded icon (uses Rust default).
+
+## v1.5.0 — 2026-04-10
+
+Font rendering overhaul, scroll-to-history default, about overlay.
+
+## Earlier
+
+See git log.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,9 @@ libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]
 windows = { version = "0.58", features = [
+    "Win32_System_Console",
     "Win32_System_Diagnostics_Debug",
+    "Win32_UI_HiDpi",
     "Win32_UI_WindowsAndMessaging",
     "Win32_Graphics_Gdi",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "koi"
-version = "1.5.0"
+version = "1.6.0"
 edition = "2021"
 
 [dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+
 mod event;
 mod fonts;
 mod fonts_registrar;
@@ -2043,6 +2045,15 @@ impl ApplicationHandler<KoiEvent> for Koi {
 }
 
 fn main() {
+    #[cfg(target_os = "windows")]
+    unsafe {
+        use windows::Win32::System::Console::{AttachConsole, ATTACH_PARENT_PROCESS};
+        use windows::Win32::UI::HiDpi::{
+            SetProcessDpiAwarenessContext, DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2,
+        };
+        let _ = AttachConsole(ATTACH_PARENT_PROCESS);
+        let _ = SetProcessDpiAwarenessContext(DPI_AWARENESS_CONTEXT_PER_MONITOR_AWARE_V2);
+    }
     env_logger::init();
     fonts_registrar::register_bundled_fonts();
     let event_loop = EventLoop::<KoiEvent>::with_user_event().build().unwrap();

--- a/src/renderer/glyph_cache.rs
+++ b/src/renderer/glyph_cache.rs
@@ -29,6 +29,7 @@ pub struct GlyphCache {
     bold_key: FontKey,
     italic_key: FontKey,
     bold_italic_key: FontKey,
+    size: Size,
     cache: HashMap<GlyphKey, Glyph>,
     atlas: Atlas,
     needs_regrow: bool,
@@ -107,6 +108,7 @@ impl GlyphCache {
             bold_key,
             italic_key,
             bold_italic_key,
+            size,
             cache: HashMap::new(),
             atlas: Atlas::new(INITIAL_ATLAS_SIZE),
             needs_regrow: false,
@@ -165,7 +167,7 @@ impl GlyphCache {
         let key = GlyphKey {
             font_key,
             character: c,
-            size: crossfont::Size::new(0.), // size is already set on font
+            size: self.size,
         };
 
         if let Some(&glyph) = self.cache.get(&key) {
@@ -191,17 +193,12 @@ impl GlyphCache {
         };
 
         let buffer: Vec<u8> = match &rasterized.buffer {
-            BitmapBuffer::Rgb(data) => {
-                // Keep RGB channels for subpixel LCD antialiasing
-                data.clone()
-            }
-            BitmapBuffer::Rgba(data) => {
-                // Extract RGB channels (drop alpha) for subpixel rendering
-                data.chunks(4)
-                    .flat_map(|rgba| &rgba[..3])
-                    .copied()
-                    .collect()
-            }
+            BitmapBuffer::Rgb(data) => data.clone(),
+            BitmapBuffer::Rgba(data) => data
+                .chunks(4)
+                .flat_map(|rgba| &rgba[..3])
+                .copied()
+                .collect(),
         };
 
         let glyph = match self.atlas.insert(


### PR DESCRIPTION
Release v1.6.0. Full notes in CHANGELOG.md.

Highlights:
- Windows binary works end-to-end (K6 acceptance signed off by j on 2026-07-12)
- Fixed the 2×1-glyph-bitmap bug caused by passing Size::new(0.) to GlyphKey (crossfont clamps to 1pt on DirectWrite)
- Windows subsystem + AttachConsole so double-click launches cleanly, cmd launches still stream logs
- PerMonitorV2 DPI awareness
- CHANGELOG.md added

Known issues shipped to /docs on Windows (all cosmetic — see CHANGELOG):
- Plex Mono falls back to Consolas
- Mouse forwarding, screenshot, icon

Base main will be tagged v1.6.0 post-merge.