### PR TITLE
fix: cache rasterize failures to stop DirectWrite log spam

### DIFF
--- a/src/renderer/glyph_cache.rs
+++ b/src/renderer/glyph_cache.rs
@@ -177,18 +177,13 @@ impl GlyphCache {
         let rasterized = match self.rasterizer.get_glyph(key) {
             Ok(r) => r,
             Err(e) => {
-                log::warn!("Failed to rasterize '{}': {}", c, e);
-                return Glyph {
-
-                    width: 0.0,
-                    height: 0.0,
-                    left: 0.0,
-                    top: 0.0,
-                    uv_x: 0.0,
-                    uv_y: 0.0,
-                    uv_w: 0.0,
-                    uv_h: 0.0,
+                log::debug!("Failed to rasterize '{}': {}", c, e);
+                let empty = Glyph {
+                    width: 0.0, height: 0.0, left: 0.0, top: 0.0,
+                    uv_x: 0.0, uv_y: 0.0, uv_w: 0.0, uv_h: 0.0,
                 };
+                self.cache.insert(key, empty);
+                return empty;
             }
         };
 


### PR DESCRIPTION
On Windows, DirectWrite returns E_INVALIDARG (0x80070057) when asked to rasterize a glyph with empty bounds — space being by far the biggest offender. Previously koi returned an empty Glyph without caching, so every render pass retried and re-logged at WARN. The log filled with hundreds of identical messages per second.

Cache the empty glyph on failure and log at debug level. No behavior change beyond quieting the log; visually the terminal still renders spaces correctly (they're background cells, not glyph draws).